### PR TITLE
Refactor StatTracker to closely follow setup requirements

### DIFF
--- a/lib/stat_tracker.rb
+++ b/lib/stat_tracker.rb
@@ -1,13 +1,14 @@
+require 'csv'
 
 class StatTracker
 
-  def initialize
-    @filenames = {}
+  def initialize(filenames)
+    filenames.each do |k, v|
+      puts CSV.read(v)
+    end
   end
 
   def self.from_csv(filenames)
-    filenames.each do |k, v|
-      rows = CSV.read(v)
-    end
+    self.new(filenames)
   end
 end

--- a/runner.rb
+++ b/runner.rb
@@ -13,3 +13,4 @@
  }
 
  stat_tracker = StatTracker.from_csv(locations)
+require "pry"; binding.pry

--- a/spec/stat_tracker_spec.rb
+++ b/spec/stat_tracker_spec.rb
@@ -4,11 +4,13 @@ require './lib/stat_tracker'
  RSpec.describe StatTracker do
 
    before(:each) do
-   @stat_tracker = StatTracker.new
+   @stat_tracker = StatTracker.new({})
+
    @game_path = './data/games.csv'
    @team_path = './data/teams.csv'
    @game_teams_path = './data/game_teams.csv'
-   @filenames = {
+
+   @locations = {
      games: @game_path,
      teams: @team_path,
      game_teams: @game_teams_path
@@ -20,8 +22,6 @@ require './lib/stat_tracker'
    end
 
    it 'can access csv data' do
-
-     expect(StatTracker.from_csv(@filenames)).to be_an_instance_of(StatTracker)
+     expect(StatTracker.from_csv(@locations)).to be_an_instance_of(StatTracker)
    end
-
  end


### PR DESCRIPTION
We can discuss this in detail tomorrow, but this refactor is a very _to-the-word literal_ follow of the setup: 

- .from_csv creates a new instance

- we can read csv data in an extremely basic way, putting it to the terminal. 

To Croix's point earlier about having containers with subsets of data from each file that we can reference specifically later - we're definitely not done! 😅

I think that we'll want to write a lot more methods to read data from each .csv file in individual ways, so the data is parsed in the best way to support stats calculations in iteration 2. 