### PR TITLE
Add a gitignore file to the repo so coverage files won't be pushed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+coverage/*


### PR DESCRIPTION
This file stops a git commit -A from including coverage files in the commit.